### PR TITLE
Allow newer Terraform versions

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -15,7 +15,7 @@ fileignoreconfig:
 - filename: examples/user-managed-replication/terraform.tfvars.example
   checksum: d619606a155c5b9a63def97d621913240b58f8d36672d005a0cb39bccda26c1b
 - filename: README.md
-  checksum: 55caf0af34a7a5ae32b75b3a33ed7e6babb3db10593ea466630904e2a0001b51
+  checksum: 303763eb631a5f797a381d4a40aaaca77c290e72eaeb61c7c61ed0e0cd21ef3d
 - filename: examples/generated-secret/main.tf
   checksum: 37c8edd39b841077663467bd9053e4041092b05b040f107bd8fcb2b1adb04670
 - filename: modules/random/main.tf
@@ -29,7 +29,7 @@ fileignoreconfig:
 - filename: examples/user-managed-replication-accessors/main.tf
   checksum: 941121157484e42ad577b8eed8381a02bd6b20c770d6da143fb4b23acbdfbd7e
 - filename: modules/random/README.md
-  checksum: 71ef1aad3f2cb307ad06f7ae78fa8b9fc142800908a258f4471406f92d75064c
+  checksum: 74f59f71c9999097b0d246310b144293b4d7105c2b73648daaa445f859f241e3
 - filename: modules/random/variables.tf
   checksum: 3b8afa99f58649680dba2c3409c5a316730ec5381692355f9f532add1048a47d
 - filename: examples/all-options-generated/variables.tf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Secret Manager for Terraform
 
-> NOTE: This module is for Terraform 0.13 - use 0.12.x releases for Terraform 0.12
+> NOTE: This module is for Terraform 0.13 and newer - use 0.12.x releases for Terraform 0.12
 
 This module provides an opinionated wrapper around creating and managing secret values
 in GCP [Secret Manager](https://cloud.google.com/secret-manager) with Terraform 0.12.
@@ -13,12 +13,12 @@ the identifiers will be granted `roles/secretmanager.secretAccessor` on th
 
 ```hcl
 module "secret" {
-  source = "memes/secret-manager/google"
-  version = "1.0.1"
+  source     = "memes/secret-manager/google"
+  version    = "1.0.1"
   project_id = "my-project-id"
-  id = "my-secret"
-  secret = "T0pS3cret!"
-  accessors = ["group:team@example.com"]
+  id         = "my-secret"
+  secret     = "T0pS3cret!"
+  accessors  = ["group:team@example.com"]
 }
 ```
 
@@ -27,15 +27,16 @@ generated value.
 
 ```hcl
 module "secret" {
-  source = "memes/secret-manager/google//modules/random"
-  version = "1.0.1"
+  source     = "memes/secret-manager/google//modules/random"
+  version    = "1.0.1"
   project_id = "my-project-id"
-  id = "my-secret"
+  id         = "my-secret"
+
   # My application requires a 12 character alphanumeric password that must
   # contain at least one of these special chars: #$%@
-  length = 12
+  length            = 12
   min_special_chars = 1
-  special_char_set = "#$%@"
+  special_char_set  = "#$%@"
 }
 ```
 
@@ -46,32 +47,43 @@ module "secret" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13 |
-| google | ~> 3.44 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.44 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.44 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_secret_manager_secret.secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_member.secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_version.secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| accessors | An optional list of IAM account identifiers that will be granted accessor (read-only)<br>permission to the secret. | `list(string)` | `[]` | no |
-| id | The secret identifier to create; this value must be unique within the project. | `string` | n/a | yes |
-| labels | An optional map of label key:value pairs to assign to the secret resources.<br>Default is an empty map. | `map(string)` | `{}` | no |
-| project\_id | The GCP project identifier where the secret will be created. | `string` | n/a | yes |
-| replication\_locations | An optional list of replication locations for the secret. If the value is an<br>empty list (default) then an automatic replication policy will be applied. Use<br>this if you must have replication constrained to specific locations.<br><br>E.g. to use automatic replication policy (default)<br>replication\_locations = []<br><br>E.g. to force secrets to be replicated only in us-east1 and us-west1 regions:<br>replication\_locations = [ "us-east1", "us-west1" ] | `list(string)` | `[]` | no |
-| secret | The secret payload to store in Secret Manager. Binary values should be base64<br>encoded before use. | `string` | n/a | yes |
+| <a name="input_accessors"></a> [accessors](#input\_accessors) | An optional list of IAM account identifiers that will be granted accessor (read-only)<br>permission to the secret. | `list(string)` | `[]` | no |
+| <a name="input_id"></a> [id](#input\_id) | The secret identifier to create; this value must be unique within the project. | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of label key:value pairs to assign to the secret resources.<br>Default is an empty map. | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project identifier where the secret will be created. | `string` | n/a | yes |
+| <a name="input_replication_locations"></a> [replication\_locations](#input\_replication\_locations) | An optional list of replication locations for the secret. If the value is an<br>empty list (default) then an automatic replication policy will be applied. Use<br>this if you must have replication constrained to specific locations.<br><br>E.g. to use automatic replication policy (default)<br>replication\_locations = []<br><br>E.g. to force secrets to be replicated only in us-east1 and us-west1 regions:<br>replication\_locations = [ "us-east1", "us-west1" ] | `list(string)` | `[]` | no |
+| <a name="input_secret"></a> [secret](#input\_secret) | The secret payload to store in Secret Manager. Binary values should be base64<br>encoded before use. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| id | The fully-qualified id of the Secret Manager key that contains the secret. |
-| secret\_id | The project-local id Secret Manager key that contains the secret. Should match<br>the input `id`. |
-
+| <a name="output_id"></a> [id](#output\_id) | The fully-qualified id of the Secret Manager key that contains the secret. |
+| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | The project-local id Secret Manager key that contains the secret. Should match<br>the input `id`. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable MD033 MD034 -->

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # This module has been tested with Terraform 0.13 only.
 #
 terraform {
-  required_version = "~> 0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = "~> 3.44"
   }

--- a/modules/random/README.md
+++ b/modules/random/README.md
@@ -1,6 +1,6 @@
 # Randomly generated secret with Secret Manager for Terraform
 
-> NOTE: This module is for Terraform 0.13 - use 0.12.x releases for Terraform 0.12
+> NOTE: This module is for Terraform 0.13 and newer - use 0.12.x releases for Terraform 0.12
 
 This sub-module provides the same variables and capabilities as the base Secret
 Manager module, but will generate a random password to use as the secret value.
@@ -11,14 +11,15 @@ E.g. to create and store a random alphanumeric password of 8 chars that
 
 ```hcl
 module "password" {
-  source = "memes/secret-manager/google//modules/random"
-  version = "1.0.1"
+  source     = "memes/secret-manager/google//modules/random"
+  version    = "1.0.1"
   project_id = "my-project-id"
-  id = "my-secret"
+  id         = "my-secret"
+
   # By default, random secret value will include 16 uppercase,lowercase, numbers,
   # and special characters; let's change that for the legacy app which can only
   # accept 8 alphanumeric chars.
-  length = 8
+  length            = 8
   has_special_chars = false
 }
 ```
@@ -30,41 +31,52 @@ module "password" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13 |
-| google | ~> 3.44 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.44 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| random | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_secret"></a> [secret](#module\_secret) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_password.secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| accessors | An optional list of IAM account identifiers that will be granted accessor (read-only)<br>permission to the secret. | `list(string)` | `[]` | no |
-| has\_lower\_chars | Include lowercase alphabet characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing lowercase characters. | `bool` | `true` | no |
-| has\_numeric\_chars | Include numeric characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing numeric characters. | `bool` | `true` | no |
-| has\_special\_chars | Include special characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing special characters. | `bool` | `true` | no |
-| has\_upper\_chars | Include uppercase alphabet characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing uppercase characters. | `bool` | `true` | no |
-| id | The secret identifier to create; this value must be unique within the project. | `string` | n/a | yes |
-| labels | An optional map of label key:value pairs to assign to the secret resources.<br>Default is an empty map. | `map(string)` | `{}` | no |
-| length | The length of the random string to generate for secret value. Default is 16. | `number` | `16` | no |
-| min\_lower\_chars | The minimum number of lowercase characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude lowercase characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee lowercase characters will be excluded - set `has_lower_chars` to false<br>to exclude lowercase characters from generated secret. | `number` | `0` | no |
-| min\_numeric\_chars | The minimum number of numeric characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude numeric characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee numeric characters will be excluded - set `has_numeric_chars` to false<br>to exclude numeric characters from generated secret. | `number` | `0` | no |
-| min\_special\_chars | The minimum number of special characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude special characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee special characters will be excluded - set `has_special_chars` to false<br>to exclude special characters from generated secret. | `number` | `0` | no |
-| min\_upper\_chars | The minimum number of uppercase characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude uppercase characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee uppercase characters will be excluded - set `has_upper_chars` to false<br>to exclude uppercase characters from generated secret. | `number` | `0` | no |
-| project\_id | The GCP project identifier where the secret will be created. | `string` | n/a | yes |
-| replication\_locations | An optional list of replication locations for the secret. If the value is an<br>empty list (default) then an automatic replication policy will be applied. Use<br>this if you must have replication constrained to specific locations.<br><br>E.g. to use automatic replication policy (default)<br>replication\_locations = []<br><br>E.g. to force secrets to be replicated only in us-east1 and us-west1 regions:<br>replication\_locations = [ "us-east1", "us-west1" ] | `list(string)` | `[]` | no |
-| special\_char\_set | Override the 'special' characters used by Terraform's random\_string provider to<br>the set provided. Default is the same set as used by Terraform by default. | `string` | `"!@#$%&*()-_=+[]{}<>:?"` | no |
+| <a name="input_accessors"></a> [accessors](#input\_accessors) | An optional list of IAM account identifiers that will be granted accessor (read-only)<br>permission to the secret. | `list(string)` | `[]` | no |
+| <a name="input_has_lower_chars"></a> [has\_lower\_chars](#input\_has\_lower\_chars) | Include lowercase alphabet characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing lowercase characters. | `bool` | `true` | no |
+| <a name="input_has_numeric_chars"></a> [has\_numeric\_chars](#input\_has\_numeric\_chars) | Include numeric characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing numeric characters. | `bool` | `true` | no |
+| <a name="input_has_special_chars"></a> [has\_special\_chars](#input\_has\_special\_chars) | Include special characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing special characters. | `bool` | `true` | no |
+| <a name="input_has_upper_chars"></a> [has\_upper\_chars](#input\_has\_upper\_chars) | Include uppercase alphabet characters in the generated secret. Default is true;<br>set to false to exclude generating a secret containing uppercase characters. | `bool` | `true` | no |
+| <a name="input_id"></a> [id](#input\_id) | The secret identifier to create; this value must be unique within the project. | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | An optional map of label key:value pairs to assign to the secret resources.<br>Default is an empty map. | `map(string)` | `{}` | no |
+| <a name="input_length"></a> [length](#input\_length) | The length of the random string to generate for secret value. Default is 16. | `number` | `16` | no |
+| <a name="input_min_lower_chars"></a> [min\_lower\_chars](#input\_min\_lower\_chars) | The minimum number of lowercase characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude lowercase characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee lowercase characters will be excluded - set `has_lower_chars` to false<br>to exclude lowercase characters from generated secret. | `number` | `0` | no |
+| <a name="input_min_numeric_chars"></a> [min\_numeric\_chars](#input\_min\_numeric\_chars) | The minimum number of numeric characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude numeric characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee numeric characters will be excluded - set `has_numeric_chars` to false<br>to exclude numeric characters from generated secret. | `number` | `0` | no |
+| <a name="input_min_special_chars"></a> [min\_special\_chars](#input\_min\_special\_chars) | The minimum number of special characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude special characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee special characters will be excluded - set `has_special_chars` to false<br>to exclude special characters from generated secret. | `number` | `0` | no |
+| <a name="input_min_upper_chars"></a> [min\_upper\_chars](#input\_min\_upper\_chars) | The minimum number of uppercase characters to include in the generated secret.<br>Default is 0, which allows the randomiser logic to exclude uppercase characters<br>if needed to satisfy other `min_` rules. Note that setting to 0 will not<br>guarantee uppercase characters will be excluded - set `has_upper_chars` to false<br>to exclude uppercase characters from generated secret. | `number` | `0` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project identifier where the secret will be created. | `string` | n/a | yes |
+| <a name="input_replication_locations"></a> [replication\_locations](#input\_replication\_locations) | An optional list of replication locations for the secret. If the value is an<br>empty list (default) then an automatic replication policy will be applied. Use<br>this if you must have replication constrained to specific locations.<br><br>E.g. to use automatic replication policy (default)<br>replication\_locations = []<br><br>E.g. to force secrets to be replicated only in us-east1 and us-west1 regions:<br>replication\_locations = [ "us-east1", "us-west1" ] | `list(string)` | `[]` | no |
+| <a name="input_special_char_set"></a> [special\_char\_set](#input\_special\_char\_set) | Override the 'special' characters used by Terraform's random\_string provider to<br>the set provided. Default is the same set as used by Terraform by default. | `string` | `"!@#$%&*()-_=+[]{}<>:?"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| id | The fully-qualified id of the Secret Manager key that contains the secret. |
-| secret\_id | The project-local id Secret Manager key that contains the secret. Should match<br>the input `id`. |
-
+| <a name="output_id"></a> [id](#output\_id) | The fully-qualified id of the Secret Manager key that contains the secret. |
+| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | The project-local id Secret Manager key that contains the secret. Should match<br>the input `id`. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable MD033 MD034 -->

--- a/modules/random/main.tf
+++ b/modules/random/main.tf
@@ -1,7 +1,7 @@
 # This module has been tested with Terraform 0.13 only.
 #
 terraform {
-  required_version = "~> 0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = "~> 3.44"
   }


### PR DESCRIPTION
Allow this module to be used with newer versions of Terraform by changing the version constraint from `~> 0.13` to `>= 0.13`