### PR TITLE
fix: Workload identity principals as accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Secret Manager for Terraform 0.14+
 
 ![GitHub release](https://img.shields.io/github/v/release/memes/terraform-google-secret-manager?sort=semver)
-![Maintenance](https://img.shields.io/maintenance/yes/2024)
+![Maintenance](https://img.shields.io/maintenance/yes/2025)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 This module provides an opinionated wrapper around creating and managing secret values
@@ -21,7 +21,7 @@ the identifiers will be granted `roles/secretmanager.secretAccessor` on the secr
 ```hcl
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = "my-project-id"
   id         = "my-secret"
   secret     = "T0pS3cret!"

--- a/examples/accessors/main.tf
+++ b/examples/accessors/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = var.secret

--- a/examples/all-options/main.tf
+++ b/examples/all-options/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 module "secret" {
   source      = "memes/secret-manager/google"
-  version     = "2.2.1"
+  version     = "2.3.0"
   project_id  = var.project_id
   id          = var.id
   replication = var.replication

--- a/examples/auto-replication-with-key/main.tf
+++ b/examples/auto-replication-with-key/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 module "secret" {
   source                        = "memes/secret-manager/google"
-  version                       = "2.2.1"
+  version                       = "2.3.0"
   project_id                    = var.project_id
   id                            = var.id
   secret                        = var.secret

--- a/examples/empty-secret-value/main.tf
+++ b/examples/empty-secret-value/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = null

--- a/examples/pubsub/main.tf
+++ b/examples/pubsub/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = var.secret

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = var.secret

--- a/examples/ttl/main.tf
+++ b/examples/ttl/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = var.secret

--- a/examples/user-managed-replication-accessors/main.tf
+++ b/examples/user-managed-replication-accessors/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 module "secret" {
   source      = "memes/secret-manager/google"
-  version     = "2.2.1"
+  version     = "2.3.0"
   project_id  = var.project_id
   id          = var.id
   secret      = var.secret

--- a/examples/user-managed-replication-with-keys/main.tf
+++ b/examples/user-managed-replication-with-keys/main.tf
@@ -12,7 +12,7 @@ terraform {
 
 module "secret" {
   source      = "memes/secret-manager/google"
-  version     = "2.2.1"
+  version     = "2.3.0"
   project_id  = var.project_id
   id          = var.id
   secret      = var.secret

--- a/examples/user-managed-replication/main.tf
+++ b/examples/user-managed-replication/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 module "secret" {
   source      = "memes/secret-manager/google"
-  version     = "2.2.1"
+  version     = "2.3.0"
   project_id  = var.project_id
   id          = var.id
   secret      = var.secret

--- a/examples/with-random-provider/main.tf
+++ b/examples/with-random-provider/main.tf
@@ -34,7 +34,7 @@ resource "random_string" "secret" {
 # Allow module to create the secret without a value
 module "secret" {
   source     = "memes/secret-manager/google"
-  version    = "2.2.1"
+  version    = "2.3.0"
   project_id = var.project_id
   id         = var.id
   secret     = null

--- a/test/profiles/secrets/inspec.yml
+++ b/test/profiles/secrets/inspec.yml
@@ -3,7 +3,7 @@ name: secrets
 title: Google Secret Manager verifier
 maintainer: Matthew Emes <memes@matthewemes.com>
 license: Apache-2.0
-version: 2.2.1
+version: 2.3.0
 supports:
   - platform: gcp
 depends:

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "accessors" {
   type    = list(string)
   default = []
   validation {
-    condition     = var.accessors == null ? true : length(join("", [for acct in var.accessors : can(regex("^(?:group|serviceAccount|user):[^@]+@[^@]*$", acct)) ? "x" : ""])) == length(var.accessors)
+    condition     = var.accessors == null ? true : length(join("", [for acct in var.accessors : can(regex("^(?:group|serviceAccount|user):[^@]+@[^@]*$", acct)) || can(regex("^principal://iam.googleapis.com/projects/", acct)) ? "x" : ""])) == length(var.accessors)
     error_message = "Each accessors value must be a valid IAM account identifier; e.g. user:jdoe@company.com, group:admins@company.com, serviceAccount:service@project.iam.gserviceaccount.com."
   }
   description = <<EOD


### PR DESCRIPTION
Modifies the validation logic on `accessors` to allow workload identity principals to be passed into function. Updated docs and examples ahead of new release.

Closes #103